### PR TITLE
Remove codecov package from tox configuration.

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -14,8 +14,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-latest, ubuntu-18.04, ubuntu-20.04, windows-latest]
-        python-version: ['3.7', '3.8', '3.9', '3.10']
+        os: [macos-latest, ubuntu-20.04, ubuntu-22.04, windows-latest]
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
 
     steps:
       - uses: actions/checkout@v2
@@ -37,7 +37,7 @@ jobs:
           python -m pip install -r requirements.txt
 
       - name: Install tools (Linux)
-        if: matrix.os == 'ubuntu-18.04' || matrix.os == 'ubuntu-20.04'
+        if: matrix.os == 'ubuntu-20.04' || matrix.os == 'ubuntu-22.04'
         run: |
           git clone https://github.com/KCL-Planning/VAL
           cd VAL/scripts/linux
@@ -52,13 +52,13 @@ jobs:
           mypy --ignore-missing-imports --strict src/
 
       - name: Statick Markdown
-        if: matrix.os == 'ubuntu-18.04' || matrix.os == 'ubuntu-20.04'
+        if: matrix.os == 'ubuntu-20.04' || matrix.os == 'ubuntu-22.04'
         uses: sscpac/statick-action@v0.0.2
         with:
           profile: documentation.yaml
 
       - name: Sphinx lint
-        if: matrix.os == 'ubuntu-18.04' || matrix.os == 'ubuntu-20.04'
+        if: matrix.os == 'ubuntu-20.04' || matrix.os == 'ubuntu-22.04'
         uses: ammaraskar/sphinx-action@master
         with:
           docs-folder: 'docs/'
@@ -73,7 +73,7 @@ jobs:
           fail_ci_if_error: false
 
       - name: Statick
-        if: matrix.os == 'ubuntu-18.04' || matrix.os == 'ubuntu-20.04'
+        if: matrix.os == 'ubuntu-20.04' || matrix.os == 'ubuntu-22.04'
         uses: sscpac/statick-action@v0.0.2
         with:
           profile: self_check.yaml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## Unreleased
 
-### Added
+### Removed
 
-### Changed
-
-### Fixed
+- Removed deprecated pypi package [codecov](https://github.com/codecov/codecov-python) from Tox configuration. (#74)
+  Discussion at: <https://community.codecov.com/t/codecov-yanked-from-pypi-all-versions/4259>.
 
 ## v0.2.1 - 2022-10-10
 

--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,7 @@ setup(
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
         "Topic :: Software Development :: Testing",
     ],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py37, py38, py39, py310
+envlist = py37, py38, py39, py310, py311
 skip_missing_interpreters = true
 
 [pytest]
@@ -28,6 +28,7 @@ python =
     3.8: py38
     3.9: py39
     3.10: py310
+    3.11: py310
 
 [testenv]
 passenv = CI

--- a/tox.ini
+++ b/tox.ini
@@ -28,7 +28,7 @@ python =
     3.8: py38
     3.9: py39
     3.10: py310
-    3.11: py310
+    3.11: py311
 
 [testenv]
 passenv = CI

--- a/tox.ini
+++ b/tox.ini
@@ -33,7 +33,6 @@ python =
 passenv = CI
 changedir = {toxinidir}/output-{envname}
 deps =
-    codecov
     flake8<5  # Pin until https://github.com/tholo/pytest-flake8/issues/87 is fixed.
     flake8-pep3101
     pycodestyle<2.9.0  # Pin until https://github.com/tholo/pytest-flake8/issues/87 is fixed.


### PR DESCRIPTION
The package has been deprecated:
https://github.com/codecov/codecov-python

Discussion at:
https://community.codecov.com/t/codecov-yanked-from-pypi-all-versions/4259

In CI, drop Ubuntu 18.04, add Ubuntu 22.04 and Python 3.11.